### PR TITLE
speedup for unstructured interpolation

### DIFF
--- a/src/oops/generic/unstructured_interpolation_mod.F90
+++ b/src/oops/generic/unstructured_interpolation_mod.F90
@@ -132,6 +132,7 @@ ageometry = atlas_geometry("UnitSphere")
 
 ! Create KDTree
 kd = atlas_indexkdtree(ageometry)
+call kd%reserve(ngrid_in_glo)
 call kd%build(ngrid_in_glo,lons_in_glo,lats_in_glo)
 
 ! Loop over observations


### PR DESCRIPTION
## Description

The unstructured interpolation was slow due to how it was using the kdtree.

`atlas_indexkdtree` has a quirk where space needs to be allocated by calling `%reserve()` before `%build()`, otherwise the kdtree is repeatedly reallocated with each lat/lon pair in the list. The same fix was done previously for saber (https://github.com/JCSDA/saber/blob/793c072f8b7fe73f1c1b82bda4477b4f91711bed/src/saber/bump/type_tree.F90#L126)

There is no change in answers

This speeds up the 1 deg soca LETKF substantially. `GetValues` constructors previously took ~400s, and are now down to ~100s ( 1deg, 20 members, ~600k obs)