### PR TITLE
Minor change to Parameters to build on Hera with json-schema-validator loaded

### DIFF
--- a/src/oops/util/parameters/Parameters.cc
+++ b/src/oops/util/parameters/Parameters.cc
@@ -64,8 +64,8 @@ class ValidationErrorHandler : public nlohmann::json_schema::basic_error_handler
     const std::regex additionalPropertyRegex("validation failed for additional property '(.*?)': "
                                              "instance invalid as per false-schema");
     editedMessage = std::regex_replace(editedMessage, additionalPropertyRegex,
-                                       "additional properties are not allowed "
-                                       "('$1' was unexpected)");
+                                       std::string("additional properties are not allowed "
+                                       "('$1' was unexpected)"));
 
     boost::algorithm::replace_all(editedMessage, "instance not found in required enum",
                                   "unrecognized enum value");


### PR DESCRIPTION
When the json and json-schema-validator modules were loaded on Hera, the oops::Parameters class failed to build.

It's somewhat odd, as the function call signature matches https://en.cppreference.com/w/cpp/regex/regex_replace, definition 4. I'll assume that it's a compiler header deficiency that would otherwise be addressed by jedicmake's retargeting of the Intel / GCC toolchains.

With this change, the build is successful.
