### PR TITLE
remove unused functions and methods

### DIFF
--- a/src/oops/base/LocalIncrement.cc
+++ b/src/oops/base/LocalIncrement.cc
@@ -11,22 +11,6 @@
 
 namespace oops {
 
-  LocalIncrement & LocalIncrement::operator +=(const LocalIncrement & rhs) {
-    ASSERT(vars_ == rhs.vars_ && varlens_ == rhs.varlens_);
-    ASSERT(vals_.size() == rhs.vals_.size());
-    for (unsigned i=0; i < vals_.size(); ++i) {
-      vals_[i] += rhs.vals_[i];
-    }
-    return *this;
-  }
-
-  LocalIncrement & LocalIncrement::operator *=(const double & zz) {
-    for (unsigned i=0; i < vals_.size(); ++i) {
-      vals_[i] *= zz;
-    }
-    return *this;
-  }
-
   LocalIncrement & LocalIncrement::operator *=(const std::vector<double> & rhs) {
     ASSERT(vals_.size() == rhs.size());
     for (unsigned i=0; i < vals_.size(); ++i) {

--- a/src/oops/base/LocalIncrement.h
+++ b/src/oops/base/LocalIncrement.h
@@ -28,10 +28,7 @@ class LocalIncrement: public util::Printable {
   void setVals(std::vector<double> &);
 
   /// Linear algebra operators
-  LocalIncrement & operator+=(const LocalIncrement &);
-  LocalIncrement & operator*=(const double &);
   LocalIncrement & operator*=(const std::vector<double> &);
-
 
  private:
   void print(std::ostream & os) const {

--- a/src/oops/util/IntSetParser.cc
+++ b/src/oops/util/IntSetParser.cc
@@ -89,16 +89,4 @@ std::set<int> parseIntSet(const std::string & str) {
 }
 
 // -----------------------------------------------------------------------------
-
-void splitVarGroup(const std::string & vargrp, std::string & var, std::string & grp) {
-  const size_t at = vargrp.find("@");
-  var = vargrp.substr(0, at);
-  if (at != std::string::npos) {
-    grp = vargrp.substr(at + 1, std::string::npos);
-    const size_t no_at = grp.find("@");
-    ASSERT(no_at == std::string::npos);
-  }
-}
-
-// -----------------------------------------------------------------------------
 }  // namespace oops


### PR DESCRIPTION
## Description

Removes unused:
- splitVarGroup (function duplicated in oops and ufo, only ufo version is used in the code base)
- LocalIncrement methods (not used after LETKF_OOPS method was removed).