### PR TITLE
Fix MPL with oops-import.cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,8 @@ find_package( jedicmake QUIET )  # Prefer find modules from jedi-cmake
 
 if( ENABLE_MKL )
     find_package( MKL )
+else()
+    set( MKL_FOUND FALSE )
 endif()
 if( MKL_FOUND )
     set( LAPACK_LIBRARIES ${MKL_LIBRARIES} )


### PR DESCRIPTION
## Description

This very small PR fixes a bug in oops-import.cmake. If `find_package(MKL)` is not called, then `MKL_FOUND` is never defined. This variable is needed in [oops-import.cmake, lines 13 and 14](https://github.com/JCSDA/oops/blob/master/oops-import.cmake.in#L13), and without it `find_package(oops)` fails outside of bundles.

Feel free to migrate this PR to JCSDA-internal if it makes merges easier.

